### PR TITLE
bugfix 7z extraction and add example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/cmd/unarr/unarr
+/unarr
+
+.DS_Store
+.*.sw*

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,33 @@
+# This is an example goreleaser.yaml file with some sane defaults.
+# Make sure to check the documentation at http://goreleaser.com
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod download
+    # you may remove this if you don't need go generate
+    - go generate ./...
+builds:
+  - env:
+      - CGO_ENABLED=1
+    goos:
+      - linux
+      - windows
+      - darwin
+    main: ./cmd/unarr/unarr.go
+archives:
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,13 +7,35 @@ before:
     # you may remove this if you don't need go generate
     - go generate ./...
 builds:
-  - env:
+  - id: unarr-win-x64
+    # brew install mingw-w64
+    main: ./cmd/unarr/unarr.go
+    env:
       - CGO_ENABLED=1
+      - CC=x86_64-w64-mingw32-gcc
+    goarch:
+      - amd64
+    goos:
+      - windows
+  - id: unarr-linux-x64
+    # brew install FiloSottile/musl-cross/musl-cross
+    main: ./cmd/unarr/unarr.go
+    env:
+      - CGO_ENABLED=1
+      - CC=x86_64-linux-musl-gcc
+    flags:
+      - "-ldflags"
+      - '-extldflags "-static"'
     goos:
       - linux
-      - windows
-      - darwin
+    goarch:
+      - amd64
+  - id: unarr-darwin-x64
     main: ./cmd/unarr/unarr.go
+    env:
+      - CGO_ENABLED=1
+    goos:
+      - darwin
 archives:
   - replacements:
       darwin: Darwin

--- a/cmd/unarr/unarr.go
+++ b/cmd/unarr/unarr.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/gen2brain/go-unarr"
+)
+
+func main() {
+	if 3 != len(os.Args) {
+		fmt.Fprintf(os.Stderr, "Usage: unarr <archive>    <local directory>\n")
+		fmt.Fprintf(os.Stderr, "Usage: unarr ./example.7z /tmp/example/\n")
+		os.Exit(1)
+		return
+	}
+
+	archive := os.Args[1]
+	extract := os.Args[2]
+
+	a, err := unarr.NewArchive(archive)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %s\n", err)
+		os.Exit(1)
+		return
+	}
+	defer a.Close()
+
+	filenames, err := a.Extract(extract)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %s\n", err)
+		os.Exit(1)
+		return
+	}
+	for _, name := range filenames {
+		fmt.Println(name)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/gen2brain/go-unarr
+
+go 1.14

--- a/unarr.go
+++ b/unarr.go
@@ -9,6 +9,7 @@ import "C"
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -190,27 +191,25 @@ func (a *Archive) ModTime() time.Time {
 
 // ReadAll reads current entry and returns data
 func (a *Archive) ReadAll() ([]byte, error) {
-	size := a.Size()
-	read := size
+	var err error
+	var n int
 
+	size := a.Size()
 	b := make([]byte, size)
 
 	for size > 0 {
-		n, err := a.Read(b)
-		if err != nil && err != io.EOF {
-			return nil, err
+		n, err = a.Read(b)
+		if err != nil {
+			if err != io.EOF {
+				return nil, err
+			}
 		}
 
 		size -= n
-
-		if err != io.EOF {
-			read -= n
-		}
 	}
 
-	if read > 0 {
-		err := errors.New("unarr: Error Read")
-		return nil, err
+	if size > 0 {
+		return nil, fmt.Errorf("unarr read failure: %w", err)
 	}
 
 	return b, nil


### PR DESCRIPTION
- add go.mod for Go 1.11+
- add .goreleaser.yml for cross-platform builds
- add cmd/unarr as example usage
- bugfix read/size logic (was returning read errors incorrectly)
- bubble original error with `%w`