### PR TITLE
Add version info and more build / release tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /cmd/unarr/unarr
 /unarr
+/dist
 
 .DS_Store
 .*.sw*

--- a/README.md
+++ b/README.md
@@ -1,21 +1,58 @@
-## go-unarr
-[![TravisCI Build Status](https://travis-ci.org/gen2brain/go-unarr.svg?branch=master)](https://travis-ci.org/gen2brain/go-unarr) 
+# go-unarr
+
+[![TravisCI Build Status](https://travis-ci.org/gen2brain/go-unarr.svg?branch=master)](https://travis-ci.org/gen2brain/go-unarr)
 [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/vawnh8s1j3w6la9t?svg=true)](https://ci.appveyor.com/project/gen2brain/go-unarr)
-[![GoDoc](https://godoc.org/github.com/gen2brain/go-unarr?status.svg)](https://godoc.org/github.com/gen2brain/go-unarr) 
-[![Go Report Card](https://goreportcard.com/badge/github.com/gen2brain/go-unarr?branch=master)](https://goreportcard.com/report/github.com/gen2brain/go-unarr) 
+[![GoDoc](https://godoc.org/github.com/gen2brain/go-unarr?status.svg)](https://godoc.org/github.com/gen2brain/go-unarr)
+[![Go Report Card](https://goreportcard.com/badge/github.com/gen2brain/go-unarr?branch=master)](https://goreportcard.com/report/github.com/gen2brain/go-unarr)
+
 <!--[![Go Cover](http://gocover.io/_badge/github.com/gen2brain/go-unarr)](http://gocover.io/github.com/gen2brain/go-unarr)-->
 
-Golang bindings for the [unarr](https://github.com/sumatrapdfreader/sumatrapdf/tree/master/ext/unarr) library from sumatrapdf.
+> Golang bindings for the [unarr](https://github.com/sumatrapdfreader/sumatrapdf/tree/master/ext/unarr) library from sumatrapdf.
 
-unarr is a decompression library for RAR, TAR, ZIP and 7z archives.
+`unarr` is a decompression library and CLI for RAR, TAR, ZIP and 7z archives.
 
-### Installation
+## GoDoc
 
-    go get -v github.com/gen2brain/go-unarr
+See <https://pkg.go.dev/github.com/gen2brain/go-unarr>
 
-### Examples
+## Install CLI
 
-##### Open archive
+```bash
+go get github.com/gen2brain/go-unarr/cmd/unarr
+```
+
+#### Example
+
+```bash
+unarr ./example.7z ./example/
+```
+
+#### Build
+
+For one-off builds:
+
+```bash
+go build -o ./unarr ./cmd/unarr/*.go
+```
+
+For multi-platform cross-compile builds:
+
+```bash
+goreleaser --snapshot --skip-publish --rm-dist
+```
+
+See `build.sh` for **gcc toolchain** information and for manual cross-platform build instructions.
+
+## Library Examples
+
+#### Install Library
+
+```bash
+go get -v github.com/gen2brain/go-unarr
+```
+
+#### Open archive
+
 ```go
 a, err := unarr.NewArchive("test.7z")
 if err != nil {
@@ -24,7 +61,8 @@ if err != nil {
 defer a.Close()
 ```
 
-##### Read first entry from archive
+#### Read first entry from archive
+
 ```go
 err := a.Entry()
 if err != nil {
@@ -36,7 +74,9 @@ if err != nil {
     panic(err)
 }
 ```
-##### List contents of archive
+
+#### List contents of archive
+
 ```go
 list, err := a.List()
 if err != nil {
@@ -44,7 +84,8 @@ if err != nil {
 }
 ```
 
-##### Read known filename from archive
+#### Read known filename from archive
+
 ```go
 err := a.EntryFor("filename.txt")
 if err != nil {
@@ -57,7 +98,8 @@ if err != nil {
 }
 ```
 
-##### Read first 8 bytes of the entry
+#### Read first 8 bytes of the entry
+
 ```go
 err := a.Entry()
 if err != nil {
@@ -72,7 +114,8 @@ if err != nil {
 }
 ```
 
-##### Read all entries from archive
+#### Read all entries from archive
+
 ```go
 for {
     err := a.Entry()
@@ -91,7 +134,8 @@ for {
 }
 ```
 
-##### Extract contents of archive to destination path
+#### Extract contents of archive to destination path
+
 ```go
 err := a.Extract("/tmp/path")
 if err != nil {

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# This crooss-compiled for all supported cross-compile targets with goreleaser
+# from MacOS, like so:
+#     goreleaser --snapshot --skip-publish --rm-dist
+
+# It can also be cross-compiled manually, like so:
+
+mkdir -p dist
+
+export CGO_ENABLED=1
+printf "Build for Darwin (macOS) ...            "
+GOARCH=amd64 GOOS=darwin                              go build -o dist/unarr_darwin_amd64 -ldflags '-w' cmd/unarr/unarr.go
+echo "dist/unarr_darwin_amd64"
+
+# Install x86_64-w64-mingw32-gcc:
+#     brew install mingw-w64
+printf "Build for Windows ...                   "
+GOARCH=amd64 GOOS=windows CC=x86_64-w64-mingw32-gcc   go build -o dist/unarr.exe -ldflags '-w' cmd/unarr/unarr.go
+echo "dist/unarr.exe"
+
+# Install x86_64-linux-musl-gcc:
+#     brew install FiloSottile/musl-cross/musl-cross
+# can also use '-w -linkmode external -extldflags "-static"'
+printf "Build for Linux ...                     "
+GOARCH=amd64 GOOS=linux   CC=x86_64-linux-musl-gcc go build -o dist/unarr_linux_musl_amd64 --ldflags '-w -extldflags "-static"' cmd/unarr/unarr.go
+echo "dist/unarr_linux_musl_amd64"
+
+# Install arm* toolchains:
+#     brew install FiloSottile/musl-cross/musl-cross --with-arm --with-arm-hf --with-aarch64
+printf "Build for Raspberry Pi (64-bit ARM) ... "
+GOARCH=arm64 GOOS=linux   CC=aarch64-linux-musl-gcc go build -o dist/unarr_linux_musl_aarch64 --ldflags '-w -extldflags "-static"' cmd/unarr/unarr.go
+echo "dist/unarr_linux_musl_aarch64"

--- a/cmd/unarr/unarr.go
+++ b/cmd/unarr/unarr.go
@@ -7,10 +7,21 @@ import (
 	"github.com/gen2brain/go-unarr"
 )
 
+// version info as per https://goreleaser.com/customization/build/
+var (
+	version = "v0.0.0-LOCAL"
+	commit  = "g0000000"
+	date    = "0000-00-00T00:00:00Z"
+)
+
 func main() {
+	if 2 == len(os.Args) && "version" == os.Args[1] {
+		fmt.Printf("Foobar %s %s (%s)\n", version, commit, date)
+	}
+
 	if 3 != len(os.Args) {
-		fmt.Fprintf(os.Stderr, "Usage: unarr <archive>    <local directory>\n")
-		fmt.Fprintf(os.Stderr, "Usage: unarr ./example.7z /tmp/example/\n")
+		fmt.Fprintf(os.Stderr, "Usage:   unarr <archive>    <local directory>\n")
+		fmt.Fprintf(os.Stderr, "Example: unarr ./example.7z /tmp/example/\n")
 		os.Exit(1)
 		return
 	}


### PR DESCRIPTION
- [x] Add `goreleaser`-style versions in `cmd/unarr/unarr.go`
- [x] Add manual release build steps (for the benefit of those unfamiliar with goreleaser), including ARM 64
- [x] Format README.md with [Prettier](https://webinstall.dev/prettier) (and make styling consistent)
- [x] Update README with build info

## Preview the README:

There were a lot of whitespace changes with `prettier`, but the content is not that much different:

See https://github.com/coolaj86/go-unarr/tree/releases