### PR TITLE
Fixes for Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /cmd/unarr/unarr
+/cmd/unarr/unarr.exe
 /unarr
+/unarr.exe
 /dist
 
 .DS_Store

--- a/unarrc/external/unarr/common/stream.c
+++ b/unarrc/external/unarr/common/stream.c
@@ -59,7 +59,7 @@ static size_t file_read(void *data, void *buffer, size_t count)
 
 static bool file_seek(void *data, off64_t offset, int origin)
 {
-#ifdef _MSC_VER
+#ifdef _WIN32
     return _fseeki64(data, offset, origin) == 0;
 #else
 #if _POSIX_C_SOURCE >= 200112L
@@ -74,7 +74,7 @@ static bool file_seek(void *data, off64_t offset, int origin)
 
 static off64_t file_tell(void *data)
 {
-#ifdef _MSC_VER
+#ifdef _WIN32
     return _ftelli64(data);
 #elif _POSIX_C_SOURCE >= 200112L
     return ftello(data);

--- a/unarrc/external/unarr/lzmasdk/CpuArch.c
+++ b/unarrc/external/unarr/lzmasdk/CpuArch.c
@@ -217,7 +217,7 @@ BoolInt CPU_Is_InOrder()
 }
 
 #if !defined(MY_CPU_AMD64) && defined(_WIN32)
-#include <Windows.h>
+#include <windows.h>
 static BoolInt CPU_Sys_Is_SSE_Supported()
 {
   OSVERSIONINFO vi;
@@ -275,7 +275,7 @@ BoolInt CPU_IsSupported_SHA()
 // #include <stdio.h>
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 BoolInt CPU_IsSupported_AVX2()
@@ -351,7 +351,7 @@ BoolInt CPU_IsSupported_PageGB()
 
 #ifdef _WIN32
 
-#include <Windows.h>
+#include <windows.h>
 
 BoolInt CPU_IsSupported_CRC32()  { return IsProcessorFeaturePresent(PF_ARM_V8_CRC32_INSTRUCTIONS_AVAILABLE) ? 1 : 0; }
 BoolInt CPU_IsSupported_CRYPTO() { return IsProcessorFeaturePresent(PF_ARM_V8_CRYPTO_INSTRUCTIONS_AVAILABLE) ? 1 : 0; }

--- a/unarrc/external/unarr/zip/inflate.c
+++ b/unarrc/external/unarr/zip/inflate.c
@@ -9,6 +9,13 @@
 #include <string.h>
 
 #ifndef _MSC_VER
+#ifdef __forceinline
+#define FORCE_INLINE_OVERRIDE
+#endif
+#ifdef FORCE_INLINE_OVERRIDE
+#pragma push_macro("__forceinline")
+#undef __forceinline
+#endif
 #define __forceinline inline
 #endif
 
@@ -482,3 +489,7 @@ int inflate_flush(inflate_state *state, unsigned char data_in[8])
     state->in.available = keep;
     return count;
 }
+
+#ifdef FORCE_INLINE_OVERRIDE
+#pragma pop_macro("__forceinline")
+#endif


### PR DESCRIPTION
_MSC_VER doesn't work with mingw, use _WIN32 instead. This caused files above 2GB to not work on go-unarr. I didn't write a test for this since it would probably complicate tests too much.
Windows header is windows.h (for case sensitivity). This caused Linux cross compilation to fail.
Ignore unarr.exe as well. This is produced from the one the fly build instructions, so we should ignore it.
Fix interaction with GCC style forceinline being redefined.

https://github.com/selmf/unarr/pull/20