### PR TITLE
DOCS: Fix typo in readme related to extracting contents of archive.

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ for {
 #### Extract contents of archive to destination path
 
 ```go
-err := a.Extract("/tmp/path")
+_, err := a.Extract("/tmp/path")
 if err != nil {
     panic(err)
 }


### PR DESCRIPTION
`Extract` function returns 2 values and not one.

This PR updates the `README` docs to reflect that.